### PR TITLE
support preview image whose path is relative to the markdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ Bracket pair colorizers interfere with the rendering. If you use one, install th
 
 ---
 
+# FAQ
+## Q: How to make Images Preview always maximized
+Set vscode settings `Workbench › Panel: Opens Maximized` as `always`.
+
+
 # **Differences**
 
 |  | Markless | Typora |

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,7 +1,7 @@
 const vscode = require('vscode');
 const { hideDecoration, transparentDecoration, getUrlDecoration, getSvgDecoration } = require('./common-decorations');
 const { state } = require('./state');
-const {  memoize, nodeToHtml, svgToUri, htmlToSvg, DefaultMap, texToSvg, enableHoverImage } = require('./util');
+const {  memoize, nodeToHtml, svgToUri, htmlToSvg, DefaultMap, texToSvg, enableHoverImage, path } = require('./util');
 const { triggerUpdateDecorations, addDecoration, posToRange }  = require('./runner');
 const cheerio = require('cheerio');
 
@@ -325,7 +325,10 @@ function bootstrap(context) {
 			if (!match) return;
 			addDecoration(hideDecoration, start, start + 2);
 			addDecoration(getUrlDecoration(true), start + match[1].length + 2, end);
-			state.imageList.push([posToRange(start, end), node.url, node.alt || " "]);
+			const editor = vscode.window.activeTextEditor;
+			const mdFilePath = editor.document.uri.fsPath;
+			const imgPath =path.resolve(path.dirname(mdFilePath), node.url);
+			state.imageList.push([posToRange(start, end), imgPath, node.alt || " "]);
 		}]],
 		["emphasis", ["delete", (() => {
 			const strikeDecoration = vscode.window.createTextEditorDecorationType({

--- a/src/util.js
+++ b/src/util.js
@@ -137,4 +137,6 @@ const nodeToHtml = (() => {
     return (/** @type {import("unist").Node} */ node) => toHtml(toHast(node));
 })();
 
-module.exports = { DefaultMap, memoize, urlToUri, svgToUri, htmlToSvg, parser, nodeToHtml, texToSvg, enableHoverImage };
+const path = require('path');
+
+module.exports = { DefaultMap, memoize, urlToUri, svgToUri, htmlToSvg, parser, nodeToHtml, texToSvg, enableHoverImage, path };


### PR DESCRIPTION
support feature from #5 